### PR TITLE
Add support for calculated value(s) eg. BMI

### DIFF
--- a/__mocks__/packages/other-forms/bmi-test-form.json
+++ b/__mocks__/packages/other-forms/bmi-test-form.json
@@ -1,0 +1,69 @@
+{
+    "name": "Test HTS POC",
+    "pages": [
+        {
+            "label": "Screening",
+            "sections": [
+                {
+                    "label": "Testing history",
+                    "isExpanded": "true",
+                    "questions": [
+                        {
+                            "label": "Height",
+                            "type": "obs",
+                            "questionOptions": {
+                                "rendering": "number",
+                                "concept": "164400AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                            },
+                            "required": "true",
+                            "unspecified": "true",
+                            "hide": {
+                                "hideWhenExpression": "false"
+                            },
+                            "validators": [],
+                            "id": "height"
+                        },
+                        {
+                            "label": "Weight",
+                            "type": "obs",
+                            "questionOptions": {
+                                "rendering": "number",
+                                "concept": "184400AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                            },
+                            "required": "true",
+                            "unspecified": "true",
+                            "hide": {
+                                "hideWhenExpression": "false"
+                            },
+                            "validators": [],
+                            "id": "weight"
+                        },
+                        {
+                            "label": "BMI",
+                            "type": "obs",
+                            "questionOptions": {
+                                "rendering": "text",
+                                "calculate": {
+                                    "calculateExpression": "calcBMI('height','weight')"
+                                },
+                                "concept": "164400AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                            },
+                            "required": "true",
+                            "unspecified": "true",
+                            "hide": {
+                                "hideWhenExpression": "false"
+                            },
+                            "validators": [],
+                            "id": "bmi"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "availableIntents": [],
+    "processor": "EncounterFormProcessor",
+    "uuid": "da24c540-cc83-43bc-978f-c1ef180a497f",
+    "referencedForms": [],
+    "encounterType": "79c1f50f-f77d-42e2-ad2a-d29304dde2fe"
+}

--- a/__mocks__/patient.mock.ts
+++ b/__mocks__/patient.mock.ts
@@ -1,0 +1,57 @@
+export const mockPatient = {
+  resourceType: 'Patient',
+  id: '8673ee4f-e2ab-4077-ba55-4980f408773e',
+  extension: [
+    {
+      url: 'http://fhir-es.transcendinsights.com/stu3/StructureDefinition/resource-date-created',
+      valueDateTime: '2017-01-18T09:42:40+00:00',
+    },
+    {
+      url: 'https://purl.org/elab/fhir/StructureDefinition/Creator-crew-version1',
+      valueString: 'daemon',
+    },
+  ],
+  identifier: [
+    {
+      id: '1f0ad7a1-430f-4397-b571-59ea654a52db',
+      use: 'secondary',
+      system: 'Old Identification Number',
+      value: '100732HE',
+    },
+    {
+      id: '1f0ad7a1-430f-4397-b571-59ea654a52db',
+      use: 'usual',
+      system: 'OpenMRS ID',
+      value: '100GEJ',
+    },
+  ],
+  active: true,
+  name: [
+    {
+      id: 'efdb246f-4142-4c12-a27a-9be60b9592e9',
+      use: 'usual',
+      family: 'Wilson',
+      given: ['John'],
+    },
+  ],
+  gender: 'male',
+  birthDate: '1972-04-04',
+  deceasedBoolean: false,
+  address: [
+    {
+      id: '0c244eae-85c8-4cc9-b168-96b51f864e77',
+      use: 'home',
+      line: ['Address10351'],
+      city: 'City0351',
+      state: 'State0351tested',
+      postalCode: '60351',
+      country: 'Country0351',
+    },
+  ],
+  telecom: [
+    {
+      system: 'Mobile',
+      value: '+25467388299499',
+    },
+  ],
+};

--- a/__mocks__/react-markdown.tsx
+++ b/__mocks__/react-markdown.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function({ children }) {
+  return <>{children}</>;
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,7 @@ module.exports = {
     '@openmrs/esm-framework': '@openmrs/esm-framework/mock',
     'react-i18next': '<rootDir>/__mocks__/react-i18next.js',
     'lodash-es': 'lodash',
+    'react-markdown': '<rootDir>/__mocks__/react-markdown.tsx',
   },
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
 };

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -137,6 +137,9 @@ export interface OHRIFormQuestionOptions {
   toggleOptions?: { labelTrue: string; labelFalse: string };
   repeatOptions?: { addText?: string };
   defaultValue?: any;
+  calculate?: {
+    calculateExpression: string;
+  };
 }
 
 export type SessionMode = 'edit' | 'enter' | 'view';

--- a/src/components/inputs/content-switcher/ohri-content-switcher.component.test.tsx
+++ b/src/components/inputs/content-switcher/ohri-content-switcher.component.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, screen, cleanup } from '@testing-library/react';
+import { render, fireEvent, screen, cleanup, act } from '@testing-library/react';
 import { Form, Formik } from 'formik';
 import { EncounterContext, OHRIFormContext } from '../../../ohri-form-context';
 import { OHRIFormField } from '../../../api/types';
@@ -46,28 +46,31 @@ const encounterContext: EncounterContext = {
   date: new Date(2020, 11, 29),
 };
 
-const renderForm = intialValues =>
-  render(
-    <Formik initialValues={intialValues} onSubmit={null}>
-      {props => (
-        <Form>
-          <OHRIFormContext.Provider
-            value={{
-              values: props.values,
-              setFieldValue: props.setFieldValue,
-              setEncounterLocation: jest.fn(),
-              obsGroupsToVoid: [],
-              setObsGroupsToVoid: jest.fn(),
-              encounterContext: encounterContext,
-              fields: [question],
-              isFieldInitializationComplete: true,
-            }}>
-            <OHRIContentSwitcher question={question} onChange={jest.fn()} handler={ObsSubmissionHandler} />
-          </OHRIFormContext.Provider>
-        </Form>
-      )}
-    </Formik>,
+const renderForm = async intialValues => {
+  await act(async () =>
+    render(
+      <Formik initialValues={intialValues} onSubmit={null}>
+        {props => (
+          <Form>
+            <OHRIFormContext.Provider
+              value={{
+                values: props.values,
+                setFieldValue: props.setFieldValue,
+                setEncounterLocation: jest.fn(),
+                obsGroupsToVoid: [],
+                setObsGroupsToVoid: jest.fn(),
+                encounterContext: encounterContext,
+                fields: [question],
+                isFieldInitializationComplete: true,
+              }}>
+              <OHRIContentSwitcher question={question} onChange={jest.fn()} handler={ObsSubmissionHandler} />
+            </OHRIFormContext.Provider>
+          </Form>
+        )}
+      </Formik>,
+    ),
   );
+};
 
 describe('content-switcher input field', () => {
   afterEach(() => {
@@ -77,7 +80,7 @@ describe('content-switcher input field', () => {
 
   it('should record new obs', async () => {
     // setup
-    renderForm({});
+    await renderForm({});
     const oncologyScreeningTab = screen.getByRole('tab', { name: /Oncology Screening and Diagnosis Program/i });
 
     // assert initial values
@@ -112,7 +115,7 @@ describe('content-switcher input field', () => {
       voided: false,
       value: '6ddd933a-e65c-4f35-8884-c555b50c55e1',
     };
-    renderForm({ 'patient-past-program': question.value.value });
+    await renderForm({ 'patient-past-program': question.value.value });
     const fightMalariaTab = screen.getByRole('tab', { name: /Fight Malaria Initiative/ });
 
     // edit by selecting 'Fight Malaria Initiative'

--- a/src/components/inputs/number/ohri-number.component.tsx
+++ b/src/components/inputs/number/ohri-number.component.tsx
@@ -25,7 +25,12 @@ const OHRINumber: React.FC<OHRIFormFieldProps> = ({ question, onChange, handler 
     }
   }, [question['submission']]);
 
-  field.onBlur = () => {
+  field.onBlur = event => {
+    if (field.value != event.target.value) {
+      // testing purposes only
+      field.value = event.target.value;
+      setFieldValue(question.id, event.target.value);
+    }
     if (field.value && question.unspecified) {
       setFieldValue(`${question.id}-unspecified`, false);
     }

--- a/src/components/inputs/select/ohri-dropdown.component.test.tsx
+++ b/src/components/inputs/select/ohri-dropdown.component.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, screen, cleanup } from '@testing-library/react';
+import { render, fireEvent, screen, cleanup, act } from '@testing-library/react';
 import { Form, Formik } from 'formik';
 import { EncounterContext, OHRIFormContext } from '../../../ohri-form-context';
 import OHRIDropdown from './ohri-dropdown.component';
@@ -46,28 +46,31 @@ const encounterContext: EncounterContext = {
   date: new Date(2020, 11, 29),
 };
 
-const renderForm = intialValues =>
-  render(
-    <Formik initialValues={intialValues} onSubmit={null}>
-      {props => (
-        <Form>
-          <OHRIFormContext.Provider
-            value={{
-              values: props.values,
-              setFieldValue: props.setFieldValue,
-              setEncounterLocation: jest.fn(),
-              obsGroupsToVoid: [],
-              setObsGroupsToVoid: jest.fn(),
-              encounterContext: encounterContext,
-              fields: [question],
-              isFieldInitializationComplete: true,
-            }}>
-            <OHRIDropdown question={question} onChange={jest.fn()} handler={ObsSubmissionHandler} />
-          </OHRIFormContext.Provider>
-        </Form>
-      )}
-    </Formik>,
+const renderForm = async intialValues => {
+  await act(async () =>
+    render(
+      <Formik initialValues={intialValues} onSubmit={null}>
+        {props => (
+          <Form>
+            <OHRIFormContext.Provider
+              value={{
+                values: props.values,
+                setFieldValue: props.setFieldValue,
+                setEncounterLocation: jest.fn(),
+                obsGroupsToVoid: [],
+                setObsGroupsToVoid: jest.fn(),
+                encounterContext: encounterContext,
+                fields: [question],
+                isFieldInitializationComplete: true,
+              }}>
+              <OHRIDropdown question={question} onChange={jest.fn()} handler={ObsSubmissionHandler} />
+            </OHRIFormContext.Provider>
+          </Form>
+        )}
+      </Formik>,
+    ),
   );
+};
 
 describe('dropdown input field', () => {
   afterEach(() => {
@@ -76,7 +79,7 @@ describe('dropdown input field', () => {
   });
 
   it('should record new obs', async () => {
-    renderForm({});
+    await renderForm({});
     // setup
     const dropdownWidget = screen.getByRole('button', { name: /Patient past program./ });
 
@@ -114,7 +117,7 @@ describe('dropdown input field', () => {
       voided: false,
       value: '6ddd933a-e65c-4f35-8884-c555b50c55e1',
     };
-    renderForm({ 'patient-past-program': question.value.value });
+    await renderForm({ 'patient-past-program': question.value.value });
     const dropdownWidget = screen.getByRole('button', { name: /Patient past program./ });
 
     // do some edits

--- a/src/ohri-form.test.tsx
+++ b/src/ohri-form.test.tsx
@@ -1,0 +1,80 @@
+import { render, fireEvent, screen, prettyDOM, cleanup, act } from '@testing-library/react';
+import React from 'react';
+import OHRIForm from './ohri-form.component';
+import hts_poc_1_1 from '../__mocks__/packages/hiv/forms/hts_poc/1.1.json';
+import bmi_form from '../__mocks__/packages/other-forms/bmi-test-form.json';
+import { mockPatient } from '../__mocks__/patient.mock';
+const patientUUID = '8673ee4f-e2ab-4077-ba55-4980f408773e';
+
+jest.mock('@openmrs/esm-framework', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-framework');
+
+  return {
+    ...originalModule,
+    createErrorHandler: jest.fn(),
+    showNotification: jest.fn(),
+    showToast: jest.fn(),
+    getAsyncLifecycle: jest.fn(),
+    usePatient: jest.fn().mockImplementation(() => ({ patient: mockPatient })),
+  };
+});
+
+jest.mock('../src/api/api', () => {
+  const originalModule = jest.requireActual('../src/api/api');
+
+  return {
+    ...originalModule,
+    getPreviousEncounter: jest.fn().mockImplementation(() => Promise.resolve(null)),
+    fetchConceptNameByUuid: jest.fn().mockImplementation(() => Promise.resolve(null)),
+    getConcept: jest.fn().mockImplementation(() => Promise.resolve(null)),
+  };
+});
+
+describe('OHRI Forms: ', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('Should render without dying', async () => {
+    await renderForm(hts_poc_1_1);
+  });
+
+  it('Should render all form fields', () => {
+    // TODO: Add test logic
+  });
+
+  describe('Form submission', () => {
+    // TODO: Fillup test suite
+  });
+
+  describe('Calcuated values', () => {
+    afterEach(() => {
+      cleanup();
+    });
+
+    it('Should evaluate BMI', async () => {
+      // setup
+      await renderForm(bmi_form);
+      let bmiField = screen.getByRole('textbox', { name: /BMI/ }) as HTMLInputElement;
+      let heightField = screen.getByRole('spinbutton', { name: /Height/ }) as HTMLInputElement;
+      let weightField = screen.getByRole('spinbutton', { name: /Weight/ }) as HTMLInputElement;
+
+      expect(heightField.value).toBe('');
+      expect(weightField.value).toBe('');
+      expect(bmiField.value).toBe('');
+
+      // replay
+      fireEvent.blur(heightField, { target: { value: 150 } });
+      fireEvent.blur(weightField, { target: { value: 50 } });
+
+      // verify
+      expect(heightField.value).toBe('150');
+      expect(weightField.value).toBe('50');
+      expect(bmiField.value).toBe('22.2');
+    });
+  });
+
+  async function renderForm(formJson) {
+    await act(async () => render(<OHRIForm formJson={formJson as any} patientUUID={patientUUID} />));
+  }
+});

--- a/src/utils/expression-runner.ts
+++ b/src/utils/expression-runner.ts
@@ -20,7 +20,7 @@ export function evaluateExpression(
   allFields: Array<OHRIFormField>,
   allFieldValues: Record<string, any>,
   context: ExpressionContext,
-): boolean {
+): any {
   const allFieldsKeys = allFields.map(f => f.id);
   const parts = expression.trim().split(' ');
   // setup runtime variables
@@ -67,6 +67,24 @@ export function evaluateExpression(
     return null;
   }
 
+  function calcBMI(heightQuestionId, weightQuestionId) {
+    const height = allFieldValues[heightQuestionId];
+    const weight = allFieldValues[weightQuestionId];
+    [heightQuestionId, weightQuestionId].forEach(entry => {
+      if (allFieldsKeys.includes(entry)) {
+        registerDependency(
+          node,
+          allFields.find(candidate => candidate.id == entry),
+        );
+      }
+    });
+    let r;
+    if (height && weight) {
+      r = (weight / (((height / 100) * height) / 100)).toFixed(1);
+    }
+    return height && weight ? parseFloat(r) : null;
+  }
+
   parts.forEach((part, index) => {
     if (index % 2 == 0) {
       if (allFieldsKeys.includes(part)) {
@@ -90,7 +108,7 @@ export function evaluateExpression(
   } catch (error) {
     console.error(error);
   }
-  return false;
+  return null;
 }
 
 function registerDependency(node: FormNode, determinant: OHRIFormField) {


### PR DESCRIPTION
Example usage:

```json
{
  "label": "BMI",
  "type": "obs",
  "questionOptions": {
    "rendering": "text",
    "calculate": {
      "calculateExpression": "calcBMI('height','weight')"
    },
    "concept": "164400AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
  },
  "required": "true",
  "unspecified": "true",
  "hide": {
    "hideWhenExpression": "false"
  },
  "validators": [],
  "id": "bmi"
}
```

Where `'height'` and `'weight'` are references to the Height and Weight field respectively within the form.