### PR TITLE
(feat) Use custom version comparator

### DIFF
--- a/src/utils/forms-loader.ts
+++ b/src/utils/forms-loader.ts
@@ -67,10 +67,8 @@ export function getLatestFormVersion(forms: FormJsonFile[]) {
   if (forms.length == 1) {
     return forms[0];
   }
-  const latest = semver.maxSatisfying(
-    forms.map(f => f.semanticVersion),
-    '*',
-  );
+  const candidates = forms.map(f => f.semanticVersion);
+  const latest = candidates.sort(formsVersionComparator)[candidates.length - 1];
   return forms.find(f => f.semanticVersion == latest);
 }
 
@@ -264,4 +262,41 @@ export function updateExcludeIntentBehaviour(excludedIntents: Array<string>, ori
 
 export function addToBaseFormsRegistry(customRegistry: Record<string, any>) {
   baseRegistry = { ...baseRegistry, ...customRegistry };
+}
+
+function isPositiveInteger(x) {
+  return /^\d+$/.test(x);
+}
+
+function formsVersionComparator(v1, v2) {
+  var v1parts = v1.split('.');
+  var v2parts = v2.split('.');
+  // First, validate both numbers are true version numbers
+  function validateParts(parts) {
+    for (var i = 0; i < parts.length; ++i) {
+      if (!isPositiveInteger(parts[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  if (!validateParts(v1parts) || !validateParts(v2parts)) {
+    return NaN;
+  }
+  for (var i = 0; i < v1parts.length; ++i) {
+    if (v2parts.length === i) {
+      return 1;
+    }
+    if (v1parts[i] === v2parts[i]) {
+      continue;
+    }
+    if (v1parts[i] > v2parts[i]) {
+      return 1;
+    }
+    return -1;
+  }
+  if (v1parts.length != v2parts.length) {
+    return -1;
+  }
+  return 0;
 }


### PR DESCRIPTION
We have been using [semver](https://github.com/npm/node-semver) a standard library for Node for managing versions. Most parts of the engine are still using semver. This PR changes the comparison logic between different versions and evaluate the greatest version, for some reasons, semver fails with:

<img width="794" alt="Screenshot 2022-06-22 at 16 44 52" src="https://user-images.githubusercontent.com/26084581/175056133-fa0bd332-9e84-45f3-9e2b-354a5a4bd3ef.png">

