### PR TITLE
Introduce Error boundary at the field level

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lodash-es": "^4.17.15",
     "moment": "^2.29.1",
     "react-anchor-link-smooth-scroll": "^1.0.12",
+    "react-error-boundary": "3.1.4",
     "react-markdown": "^7.1.0",
     "react-scroll": "^1.8.2",
     "react-test-renderer": "^16.9.0",

--- a/src/utils/expression-runner.ts
+++ b/src/utils/expression-runner.ts
@@ -21,6 +21,9 @@ export function evaluateExpression(
   allFieldValues: Record<string, any>,
   context: ExpressionContext,
 ): any {
+  if (!expression?.trim()) {
+    return null;
+  }
   const allFieldsKeys = allFields.map(f => f.id);
   const parts = parseExpression(expression.trim());
   // setup function scope
@@ -64,6 +67,9 @@ export async function evaluateAsyncExpression(
   allFieldValues: Record<string, any>,
   context: ExpressionContext,
 ): Promise<any> {
+  if (!expression?.trim()) {
+    return null;
+  }
   const allFieldsKeys = allFields.map(f => f.id);
   const parts = parseExpression(expression.trim());
   // setup function scope

--- a/yarn.lock
+++ b/yarn.lock
@@ -2744,6 +2744,7 @@ __metadata:
     pretty-quick: ^1.11.1
     react: ^18.2.0
     react-anchor-link-smooth-scroll: ^1.0.12
+    react-error-boundary: 3.1.4
     react-i18next: ^11.18.1
     react-markdown: ^7.1.0
     react-scroll: ^1.8.2
@@ -13153,6 +13154,17 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
   checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
+  languageName: node
+  linkType: hard
+
+"react-error-boundary@npm:3.1.4":
+  version: 3.1.4
+  resolution: "react-error-boundary@npm:3.1.4"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+  peerDependencies:
+    react: ">=16.13.1"
+  checksum: f36270a5d775a25c8920f854c0d91649ceea417b15b5bc51e270a959b0476647bb79abb4da3be7dd9a4597b029214e8fe43ea914a7f16fa7543c91f784977f1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR introduces an error boundary at the field level within a section. This makes the engine more resilient with rendering arbitrary forms schemas at the field level.

Below is case scenario were we try to render an Ampath complex form with unsupported types:

<img width="855" alt="Screenshot 2023-03-01 at 19 08 51" src="https://user-images.githubusercontent.com/26084581/222196607-b8410ce5-1e55-45b6-8bf0-37491be55bcb.png">

