### PR TITLE
(feat) add ability to use `ohri-form-engine` as an extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@ohri/openmrs-ohri-form-engine-lib",
+  "name": "@ohri/esm-form-engine-app",
   "version": "1.0.1",
   "description": "A React based Forms Engine for OpenMRS 3.X",
-  "browser": "dist/openmrs-ohri-form-engine-lib.js",
+  "browser": "dist/openmrs-esm-form-engine-app.js",
   "main": "src/index.ts",
   "license": "MIT",
   "homepage": "https://github.com/UCSF-IGHS/openmrs-ohri-form-engine-lib#readme",
@@ -11,7 +11,8 @@
     "prettier": "prettier --config prettier.config.js --write \"src/**/*.{ts,tsx}\"",
     "typescript": "tsc",
     "test": "jest --config ./jest.config.js --passWithNoTests",
-    "build": "webpack --mode production"
+    "build": "webpack",
+    "start": "openmrs develop --port 8085"
   },
   "browserslist": [
     "extends browserslist-config-openmrs"

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,37 @@ export * from './ohri-form-context';
 export * from './components/value/view/ohri-field-value-view.component';
 export * from './components/previous-value-review/previous-value-review.component';
 export { default as OHRIForm } from './ohri-form.component';
+
+import { defineConfigSchema, getAsyncLifecycle } from '@openmrs/esm-framework';
+
+declare var __VERSION__: string;
+// __VERSION__ is replaced by Webpack with the version from package.json
+const version = __VERSION__;
+
+const backendDependencies = {
+  'webservices.rest': '^2.2.0',
+  fhir2: '^1.2.0',
+};
+
+function setupOpenMRS() {
+  const moduleName = '@ohri/esm-form-engine-app';
+
+  const options = {
+    featureName: 'ohri-form-engine',
+    moduleName,
+  };
+
+  defineConfigSchema(moduleName, {});
+
+  return {
+    extensions: [
+      {
+        name: 'ohri-form-engine',
+        slot: 'ohri-form-engine-slot',
+        load: getAsyncLifecycle(() => import('./ohri-form.component'), options),
+      },
+    ],
+  };
+}
+
+export { backendDependencies, setupOpenMRS, version };

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,2 +1,4 @@
 import '@testing-library/jest-dom/extend-expect';
 import 'jest-when';
+
+global.__VERSION__ = '1.0.0';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2670,9 +2670,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ohri/openmrs-ohri-form-engine-lib@workspace:.":
+"@ohri/esm-form-engine-app@workspace:.":
   version: 0.0.0-use.local
-  resolution: "@ohri/openmrs-ohri-form-engine-lib@workspace:."
+  resolution: "@ohri/esm-form-engine-app@workspace:."
   dependencies:
     "@carbon/react": ^1.13.0
     "@openmrs/esm-framework": next
@@ -8546,7 +8546,7 @@ __metadata:
 
 "fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=18f3a7"
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:
     node-gyp: latest
   conditions: os=darwin
@@ -14115,7 +14115,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.9.0#~builtin<compat/resolve>":
   version: 1.22.1
-  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7
@@ -15745,17 +15745,17 @@ __metadata:
 
 "typescript@patch:typescript@^4.0.3#~builtin<compat/typescript>":
   version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=a1c5e5"
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=ad5954"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 2eee5c37cad4390385db5db5a8e81470e42e8f1401b0358d7390095d6f681b410f2c4a0c496c6ff9ebd775423c7785cdace7bcdad76c7bee283df3d9718c0f20
+  checksum: 8f6260acc86b56bfdda6004bc53f32ea548f543e8baef7071c8e34d29d292f3e375c8416556c8de10b24deef6933cd1c16a8233dc84a3dd43a13a13265d0faab
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@~4.5.2#~builtin<compat/typescript>":
   version: 4.5.5
-  resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=a1c5e5"
+  resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=bcec9a"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
### What does this PR do?

It exposes the `OHRI FORM ENGINE` as an extension. This is to enable for its usage across multiple place like the fast data entry app, the clinical workspace on patient chart.


### Screenshoot

![ohri-form](https://user-images.githubusercontent.com/28008754/228255986-8cedb903-c93f-4cfc-b4ff-2505aec11138.gif)


@samuelmale i think moving it away from being a library is best to take advantage of the extension system